### PR TITLE
feature - support cpu inference

### DIFF
--- a/train.py
+++ b/train.py
@@ -44,6 +44,9 @@ if __name__ == '__main__':
     args = parse_args()
     logging.basicConfig(level=logging.DEBUG if args.debug else logging.INFO)
 
+    device = 'cuda' if torch.cuda.is_available() else 'cpu'
+    logging.info(f'running training on {device}')
+
     logging.info('creating dataset and data loaders')
 
     # assert args.train != args.val
@@ -60,7 +63,7 @@ if __name__ == '__main__':
 
     logging.info(f'creating {args.model_type} and optimizer with initial lr of {args.initial_lr}')
     model = models[args.model_type](train_dataset.categories)
-    model = nn.DataParallel(model).cuda()
+    model = nn.DataParallel(model).to(device)
     optimizer = optim.RMSprop(params=[p for p in model.parameters() if p.requires_grad], lr=args.initial_lr)
 
     logging.info('creating trainer and evaluator engines')
@@ -69,7 +72,7 @@ if __name__ == '__main__':
         model=model,
         optimizer=optimizer,
         loss_fn=loss_fn,
-        device='cuda',
+        device=device,
         non_blocking=True,
     )
 


### PR DESCRIPTION
In this PR we add support for CPU training and inference; this required minor modifications to `train` and `evaluate_images`. To test this PR, both scripts were run with `CUDA_VISIBLE_DEVICES=-1` so they weren't visible when the application ran. Also checked this by running `nvidia-smi` in another window.

This resolves #15 